### PR TITLE
Windows native calls fix

### DIFF
--- a/src/amx.rs
+++ b/src/amx.rs
@@ -73,8 +73,8 @@ impl AMX {
     /// use samp_sdk::amx::{AMX, AmxResult};
     /// use samp_sdk::consts::AMX_ERR_NONE;
     ///
-    /// extern "system" fn some_function(_: *mut types::AMX, _: *mut i32) -> i32 { 0 }
-    /// extern "system" fn another_function(_: *mut types::AMX, _: *mut i32) -> i32 { 0 }
+    /// extern "C" fn some_function(_: *mut types::AMX, _: *mut i32) -> i32 { 0 }
+    /// extern "C" fn another_function(_: *mut types::AMX, _: *mut i32) -> i32 { 0 }
     ///
     /// fn amx_load(amx: &AMX) -> types::Cell {
     ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,8 +14,8 @@ Most of them hide raw C bindings and exports to make code easier to understand.
 /// use samp_sdk::types;
 ///
 /// fn amx_load(amx: &AMX) {
-///     extern "system" fn show_something(_: *mut types::AMX, _: *mut i32) -> i32 { 0 }
-///     extern "system" fn where_is_player(_: *mut types::AMX, _: *mut i32) -> i32 { 0 }
+///     extern "C" fn show_something(_: *mut types::AMX, _: *mut i32) -> i32 { 0 }
+///     extern "C" fn where_is_player(_: *mut types::AMX, _: *mut i32) -> i32 { 0 }
 ///
 ///     let natives = natives![
 ///        { "ShowSomething", show_something },
@@ -222,7 +222,7 @@ macro_rules! log {
 #[macro_export]
 macro_rules! define_native {
     ($name:ident as raw) => {
-        pub extern "system" fn $name(amx: *mut $crate::types::AMX, params: *mut $crate::types::Cell) -> $crate::types::Cell {
+        pub extern "C" fn $name(amx: *mut $crate::types::AMX, params: *mut $crate::types::Cell) -> $crate::types::Cell {
             let mut amx = $crate::amx::AMX::new(amx);
             match super::___PLUGIN.lock().unwrap().$name(&mut amx, params) {
                 Ok(res) => return res,
@@ -235,7 +235,7 @@ macro_rules! define_native {
     };
 
     ($name:ident) => {
-        pub extern "system" fn $name(amx: *mut $crate::types::AMX, _: *mut $crate::types::Cell) -> $crate::types::Cell {
+        pub extern "C" fn $name(amx: *mut $crate::types::AMX, _: *mut $crate::types::Cell) -> $crate::types::Cell {
             let mut amx = $crate::amx::AMX::new(amx);
             match super::___PLUGIN.lock().unwrap().$name(&mut amx) {
                 Ok(res) => return res,
@@ -248,7 +248,7 @@ macro_rules! define_native {
     };
 
     ($name:ident, $( $arg:ident : $( $data:ident )+ ),* ) => {
-        pub extern "system" fn $name(amx: *mut $crate::types::AMX, params: *mut $crate::types::Cell) -> $crate::types::Cell {
+        pub extern "C" fn $name(amx: *mut $crate::types::AMX, params: *mut $crate::types::Cell) -> $crate::types::Cell {
             let mut amx = $crate::amx::AMX::new(amx);
             expand_args!(amx, params, $( $arg : $( $data )+ ),* );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,9 +31,9 @@ pub struct AMX {
     pub sysreq_d: Cell,
 }
 
-pub type AmxNative = extern "system" fn(*mut AMX, params: *mut Cell) -> Cell;
-pub type AmxCallback = extern "system" fn(*mut AMX, index: Cell, result: *mut Cell, params: *mut Cell) -> i32;
-pub type AmxDebug = extern "system" fn(*mut AMX) -> i32;
+pub type AmxNative = extern "C" fn(*mut AMX, params: *mut Cell) -> Cell;
+pub type AmxCallback = extern "C" fn(*mut AMX, index: Cell, result: *mut Cell, params: *mut Cell) -> i32;
+pub type AmxDebug = extern "C" fn(*mut AMX) -> i32;
 
 #[repr(C, packed)]
 #[derive(Copy, Clone)]
@@ -78,48 +78,48 @@ pub struct AMX_HEADER {
     pub nametable: i32,
 }
 
-pub type Align16 = extern "system" fn(*mut u16) -> *mut u16;
-pub type Align32 = extern "system" fn(*mut u32) -> *mut u32;
-pub type Allot = extern "system" fn(*mut AMX, i32, *mut Cell, *mut Cell) -> i32;
-pub type Callback = extern "system" fn(*mut AMX, Cell, *mut Cell, *mut Cell) -> i32;
-pub type Cleanup = extern "system" fn(*mut AMX) -> i32;
-pub type Clone = extern "system" fn(*mut AMX, *mut AMX, *mut c_void) -> i32;
-pub type Exec = extern "system" fn(*mut AMX, *mut Cell, i32) -> i32;
-pub type FindNative = extern "system" fn(*mut AMX, *const i8, *mut i32) -> i32;
-pub type FindPublic = extern "system" fn(*mut AMX, *const i8, *mut i32) -> i32;
-pub type FindPubVar = extern "system" fn(*mut AMX, *const i8, *mut Cell) -> i32;
-pub type FindTagId = extern "system" fn(*mut AMX, Cell, *mut i8) -> i32;
-pub type Flags = extern "system" fn(*mut AMX, *mut u16) -> i32;
-pub type GetAddr = extern "system" fn(*mut AMX, Cell, *mut *mut Cell) -> i32;
-pub type GetNative = extern "system" fn(*mut AMX, i32, *mut i8) -> i32;
-pub type GetPublic = extern "system" fn(*mut AMX, i32, *mut i8) -> i32;
-pub type GetPubVar = extern "system" fn(*mut AMX, i32, *mut i8, *mut Cell) -> i32;
-pub type GetString = extern "system" fn(*mut u8, *const Cell, i32, usize) -> i32;
-pub type GetTag = extern "system" fn(*mut AMX, i32, *mut i8, *mut Cell) -> i32;
-pub type GetUserData = extern "system" fn(*mut AMX, i64, *mut *mut c_void) -> i32;
-pub type Init = extern "system" fn(*mut AMX, *mut c_void) -> i32;
-pub type InitJIT = extern "system" fn(*mut AMX, *mut c_void, *mut c_void) -> i32;
-pub type MemInfo = extern "system" fn(*mut AMX, *mut i64, *mut i64, *mut i64) -> i32;
-pub type NameLength = extern "system" fn(*mut AMX, *mut i32) -> i32;
-pub type NativeInfo = extern "system" fn(*const i8, AmxNative) -> *mut AMX_NATIVE_INFO;
-pub type NumNatives = extern "system" fn(*mut AMX, *mut i32) -> i32;
-pub type NumPublics = extern "system" fn(*mut AMX, *mut i32) -> i32;
-pub type NumPubVars = extern "system" fn(*mut AMX, *mut i32) -> i32;
-pub type NumTags = extern "system" fn(*mut AMX, *mut i32) -> i32;
-pub type Push = extern "system" fn(*mut AMX, Cell) -> i32;
-pub type PushArray = extern "system" fn(*mut AMX, *mut Cell, *mut *mut Cell, *const Cell, i32) -> i32;
-pub type PushString = extern "system" fn(*mut AMX, *mut Cell, *mut *mut Cell, *const i8, i32, i32) -> i32;
-pub type RaiseError = extern "system" fn(*mut AMX, i32) -> i32;
-pub type Register = extern "system" fn(*mut AMX, *const AMX_NATIVE_INFO, i32) -> i32;
-pub type Release = extern "system" fn(*mut AMX, Cell) -> i32;
-pub type SetCallback = extern "system" fn(*mut AMX, AmxCallback) -> i32;
-pub type SetDebugHook = extern "system" fn(*mut AMX, AmxDebug) -> i32;
-pub type SetString = extern "system" fn(*mut Cell, *const i8, i32, i32, usize) -> i32;
-pub type SetUserData = extern "system" fn(*mut AMX, i64, *mut c_void) -> i32;
-pub type StrLen = extern "system" fn(*const Cell, *mut i32) -> i32;
-pub type UTF8Check = extern "system" fn(*const i8, *mut i32) -> i32;
-pub type UTF8Get = extern "system" fn(*const i8, *mut *const i8, *mut Cell) -> i32;
-pub type UTF8Len = extern "system" fn(*const Cell, *mut i32) -> i32;
-pub type UTF8Put = extern "system" fn(*mut i8, *mut *mut i8, i32, Cell) -> i32;
+pub type Align16 = extern "C" fn(*mut u16) -> *mut u16;
+pub type Align32 = extern "C" fn(*mut u32) -> *mut u32;
+pub type Allot = extern "C" fn(*mut AMX, i32, *mut Cell, *mut Cell) -> i32;
+pub type Callback = extern "C" fn(*mut AMX, Cell, *mut Cell, *mut Cell) -> i32;
+pub type Cleanup = extern "C" fn(*mut AMX) -> i32;
+pub type Clone = extern "C" fn(*mut AMX, *mut AMX, *mut c_void) -> i32;
+pub type Exec = extern "C" fn(*mut AMX, *mut Cell, i32) -> i32;
+pub type FindNative = extern "C" fn(*mut AMX, *const i8, *mut i32) -> i32;
+pub type FindPublic = extern "C" fn(*mut AMX, *const i8, *mut i32) -> i32;
+pub type FindPubVar = extern "C" fn(*mut AMX, *const i8, *mut Cell) -> i32;
+pub type FindTagId = extern "C" fn(*mut AMX, Cell, *mut i8) -> i32;
+pub type Flags = extern "C" fn(*mut AMX, *mut u16) -> i32;
+pub type GetAddr = extern "C" fn(*mut AMX, Cell, *mut *mut Cell) -> i32;
+pub type GetNative = extern "C" fn(*mut AMX, i32, *mut i8) -> i32;
+pub type GetPublic = extern "C" fn(*mut AMX, i32, *mut i8) -> i32;
+pub type GetPubVar = extern "C" fn(*mut AMX, i32, *mut i8, *mut Cell) -> i32;
+pub type GetString = extern "C" fn(*mut u8, *const Cell, i32, usize) -> i32;
+pub type GetTag = extern "C" fn(*mut AMX, i32, *mut i8, *mut Cell) -> i32;
+pub type GetUserData = extern "C" fn(*mut AMX, i64, *mut *mut c_void) -> i32;
+pub type Init = extern "C" fn(*mut AMX, *mut c_void) -> i32;
+pub type InitJIT = extern "C" fn(*mut AMX, *mut c_void, *mut c_void) -> i32;
+pub type MemInfo = extern "C" fn(*mut AMX, *mut i32, *mut i32, *mut i32) -> i32;
+pub type NameLength = extern "C" fn(*mut AMX, *mut i32) -> i32;
+pub type NativeInfo = extern "C" fn(*const i8, AmxNative) -> *mut AMX_NATIVE_INFO;
+pub type NumNatives = extern "C" fn(*mut AMX, *mut i32) -> i32;
+pub type NumPublics = extern "C" fn(*mut AMX, *mut i32) -> i32;
+pub type NumPubVars = extern "C" fn(*mut AMX, *mut i32) -> i32;
+pub type NumTags = extern "C" fn(*mut AMX, *mut i32) -> i32;
+pub type Push = extern "C" fn(*mut AMX, Cell) -> i32;
+pub type PushArray = extern "C" fn(*mut AMX, *mut Cell, *mut *mut Cell, *const Cell, i32) -> i32;
+pub type PushString = extern "C" fn(*mut AMX, *mut Cell, *mut *mut Cell, *const i8, i32, i32) -> i32;
+pub type RaiseError = extern "C" fn(*mut AMX, i32) -> i32;
+pub type Register = extern "C" fn(*mut AMX, *const AMX_NATIVE_INFO, i32) -> i32;
+pub type Release = extern "C" fn(*mut AMX, Cell) -> i32;
+pub type SetCallback = extern "C" fn(*mut AMX, AmxCallback) -> i32;
+pub type SetDebugHook = extern "C" fn(*mut AMX, AmxDebug) -> i32;
+pub type SetString = extern "C" fn(*mut Cell, *const i8, i32, i32, usize) -> i32;
+pub type SetUserData = extern "C" fn(*mut AMX, i64, *mut c_void) -> i32;
+pub type StrLen = extern "C" fn(*const Cell, *mut i32) -> i32;
+pub type UTF8Check = extern "C" fn(*const i8, *mut i32) -> i32;
+pub type UTF8Get = extern "C" fn(*const i8, *mut *const i8, *mut Cell) -> i32;
+pub type UTF8Len = extern "C" fn(*const Cell, *mut i32) -> i32;
+pub type UTF8Put = extern "C" fn(*mut i8, *mut *mut i8, i32, Cell) -> i32;
 
 pub type Logprintf_t = extern "C" fn(*const i8, ...);


### PR DESCRIPTION
After some research and analysis of samp-plugin-sdk, I've found that stdcall is only needed for:
`Load`, `Unload`, `AmxLoad`, `AmxUnload`, `Supports`, `ProcessTick`, `Supports`

Tested on windows and work fine with simple plugin.