### PR TITLE
remove unused dependency detour

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.0.2"
-detour = "0.5"
 encoding = "0.2"
 failure = "0.1.2"
 failure_derive = "0.1.2"


### PR DESCRIPTION
This dependency is not used by the library or any of its dependencies. It also forces the use of the nightly compiler currently.