### PR TITLE
fix push_string method

### DIFF
--- a/src/amx.rs
+++ b/src/amx.rs
@@ -297,7 +297,7 @@ impl AMX {
 
             for i in 0..string.len() {
                 unsafe {
-                    *(dest.offset(i as isize)) = transmute_copy(&bytes[i]);
+                    *(dest.offset(i as isize)) = transmute_copy(&(bytes[i] as  i32)) ;
                 }
             }
 


### PR DESCRIPTION
bytes needed to cast from u8 to i32 as in pawn strings each character has 32bit size